### PR TITLE
Fix header line for rcirc-controls.el

### DIFF
--- a/rcirc-controls.el
+++ b/rcirc-controls.el
@@ -1,4 +1,4 @@
-;;; rcirc-controls.el -- control sequences
+;;; rcirc-controls.el --- control sequences
 ;; Copyright 2008  Alex Schroeder
 
 ;; This program is free software; you can redistribute it and/or


### PR DESCRIPTION
We build a MELPA package from this file, and the malformatted first line stops `package-buffer-info` from parsing the metadata out of it. :-)

(See https://github.com/milkypostman/melpa/issues/1551)
